### PR TITLE
Boomerang tuning

### DIFF
--- a/src/demo/boomerang/boomerang_settings.rs
+++ b/src/demo/boomerang/boomerang_settings.rs
@@ -30,7 +30,7 @@ impl Default for BoomerangSettings {
     fn default() -> Self {
         Self {
             min_movement_speed: 15.,
-            max_movement_speed: 35.,
+            max_movement_speed: 45.,
             min_rotation_speed: 20.,
             max_rotation_speed: 45.,
             falling_speed: 5.0,

--- a/src/demo/boomerang/boomerang_settings.rs
+++ b/src/demo/boomerang/boomerang_settings.rs
@@ -5,7 +5,6 @@ pub fn plugin(app: &mut App) {
 
     // reflection
     app.register_type::<BoomerangSettings>();
-
 }
 
 #[cfg(feature = "dev")]
@@ -47,7 +46,9 @@ impl BoomerangSettings {
         self.tween_values(self.min_rotation_speed, self.max_rotation_speed, progress)
     }
 
-    fn tween_values(&self, min: f32, max:f32, progress:f32) -> f32 {
-        EasingCurve::new(min, max, self.easing_function).sample(progress).unwrap_or((min + max) / 2.)
+    fn tween_values(&self, min: f32, max: f32, progress: f32) -> f32 {
+        EasingCurve::new(min, max, self.easing_function)
+            .sample(progress)
+            .unwrap_or((min + max) / 2.)
     }
 }

--- a/src/demo/boomerang/boomerang_settings.rs
+++ b/src/demo/boomerang/boomerang_settings.rs
@@ -18,19 +18,31 @@ pub fn boomerang_dev_tools_plugin(app: &mut App) {
 #[derive(Resource, Debug, Reflect)]
 #[reflect(Resource)]
 pub struct BoomerangSettings {
-    pub movement_speed: f32,
+    pub min_movement_speed: f32,
+    pub max_movement_speed: f32,
     pub rotations_per_second: f32,
     pub falling_speed: f32,
-    pub easing_function: EaseFunction,
+    pub easing_function: EaseFunction, // see https://bevyengine.org/examples/animation/easing-functions/
 }
 
 impl Default for BoomerangSettings {
     fn default() -> Self {
         Self {
-            movement_speed: 30.0,
+            min_movement_speed: 15.,
+            max_movement_speed: 35.,
             rotations_per_second: 12.0,
             falling_speed: 5.0,
-            easing_function: EaseFunction::ElasticInOut,
+            easing_function: EaseFunction::ExponentialInOut,
         }
+    }
+}
+
+impl BoomerangSettings {
+    pub fn tween_movement_speed(&self, progress: f32) -> f32 {
+        self.tween_values(self.min_movement_speed, self.max_movement_speed, progress)
+    }
+    
+    fn tween_values(&self, min: f32, max:f32, progress:f32) -> f32 {
+        EasingCurve::new(min, max, self.easing_function).sample(progress).unwrap_or((min + max) / 2.)
     }
 }

--- a/src/demo/boomerang/boomerang_settings.rs
+++ b/src/demo/boomerang/boomerang_settings.rs
@@ -20,7 +20,8 @@ pub fn boomerang_dev_tools_plugin(app: &mut App) {
 pub struct BoomerangSettings {
     pub min_movement_speed: f32,
     pub max_movement_speed: f32,
-    pub rotations_per_second: f32,
+    pub min_rotation_speed: f32,
+    pub max_rotation_speed: f32,
     pub falling_speed: f32,
     pub easing_function: EaseFunction, // see https://bevyengine.org/examples/animation/easing-functions/
 }
@@ -30,7 +31,8 @@ impl Default for BoomerangSettings {
         Self {
             min_movement_speed: 15.,
             max_movement_speed: 35.,
-            rotations_per_second: 12.0,
+            min_rotation_speed: 20.,
+            max_rotation_speed: 45.,
             falling_speed: 5.0,
             easing_function: EaseFunction::ExponentialInOut,
         }
@@ -41,7 +43,10 @@ impl BoomerangSettings {
     pub fn tween_movement_speed(&self, progress: f32) -> f32 {
         self.tween_values(self.min_movement_speed, self.max_movement_speed, progress)
     }
-    
+    pub fn tween_rotation_speed(&self, progress: f32) -> f32 {
+        self.tween_values(self.min_rotation_speed, self.max_rotation_speed, progress)
+    }
+
     fn tween_values(&self, min: f32, max:f32, progress:f32) -> f32 {
         EasingCurve::new(min, max, self.easing_function).sample(progress).unwrap_or((min + max) / 2.)
     }

--- a/src/demo/boomerang/boomerang_settings.rs
+++ b/src/demo/boomerang/boomerang_settings.rs
@@ -1,0 +1,36 @@
+use bevy::prelude::*;
+
+pub fn plugin(app: &mut App) {
+    app.init_resource::<BoomerangSettings>();
+
+    // reflection
+    app.register_type::<BoomerangSettings>();
+
+}
+
+#[cfg(feature = "dev")]
+pub fn boomerang_dev_tools_plugin(app: &mut App) {
+    use bevy_inspector_egui::quick::ResourceInspectorPlugin;
+    app.add_plugins(ResourceInspectorPlugin::<BoomerangSettings>::default());
+}
+
+/// Current set of stats of our boomerang
+#[derive(Resource, Debug, Reflect)]
+#[reflect(Resource)]
+pub struct BoomerangSettings {
+    pub movement_speed: f32,
+    pub rotations_per_second: f32,
+    pub falling_speed: f32,
+    pub easing_function: EaseFunction,
+}
+
+impl Default for BoomerangSettings {
+    fn default() -> Self {
+        Self {
+            movement_speed: 30.0,
+            rotations_per_second: 12.0,
+            falling_speed: 5.0,
+            easing_function: EaseFunction::ElasticInOut,
+        }
+    }
+}

--- a/src/demo/boomerang/mod.rs
+++ b/src/demo/boomerang/mod.rs
@@ -195,7 +195,7 @@ fn move_flying_boomerangs(
         let origin_position = match boomerang
             .path
             .get(boomerang.path_index)
-            .ok_or(format!("No Origin for boomerang: {:?}", boomerang))?
+            .ok_or(format!("No Origin for boomerang: {boomerang:?}"))?
         {
             BoomerangTargetKind::Entity(entity) => all_other_transforms
                 .get(*entity)?
@@ -301,7 +301,7 @@ fn on_boomerang_bounce_advance_to_next_pathing_step_or_fall_down(
 
 /// Rotates our boomerangs at constant speed.
 fn rotate_boomerangs(
-    mut boomerangs: Query<(&mut Transform, &Boomerang), (With<Flying>)>,
+    mut boomerangs: Query<(&mut Transform, &Boomerang), With<Flying>>,
     time: Res<Time>,
     settings: Res<BoomerangSettings>,
 ) {

--- a/src/demo/boomerang/mod.rs
+++ b/src/demo/boomerang/mod.rs
@@ -19,11 +19,20 @@ pub mod boomerang_settings;
 pub const BOOMERANG_FLYING_HEIGHT: f32 = 0.5;
 
 /// Component used to describe boomerang entities.
-#[derive(Component, Debug, Default)]
+#[derive(Component, Debug, Default, Reflect)]
+#[reflect(Component)]
 struct Boomerang {
     /// The path this boomerang is following.
-    path: VecDeque<BoomerangTargetKind>,
-    speed: f32,
+    path: Vec<BoomerangTargetKind>,
+    path_index: usize,
+}
+impl Boomerang {
+    pub fn new (path: Vec<BoomerangTargetKind>) -> Self {
+        Self {
+            path,
+            path_index: 0,
+        }
+    }
 }
 
 /// Component used to mark boomerangs which are midair.
@@ -74,7 +83,7 @@ struct BoomerangHasFallenOnGroundEvent {
 }
 
 /// An enum to differentiate between the different kinds of targets our boomerang may want to hit.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Reflect)]
 pub enum BoomerangTargetKind {
     /// Targeting an entity means it will home in on it, even as it moves.
     Entity(Entity),
@@ -91,7 +100,7 @@ struct BoomerangPathPreview {
 
 pub fn plugin(app: &mut App) {
     app.add_plugins(boomerang_settings::plugin);
-    
+
     app.init_gizmo_group::<BoomerangPreviewGizmos>();
     app.add_event::<ThrowBoomerangEvent>();
     app.add_event::<BounceBoomerangEvent>();
@@ -149,13 +158,14 @@ fn spawn_test_entities(
 fn move_flying_boomerangs(
     mut flying_boomerangs: Query<(Entity, &Boomerang, &mut Transform), With<Flying>>,
     all_other_transforms: Query<&Transform, Without<Boomerang>>,
+    boomerang_settings: Res<BoomerangSettings>,
     time: Res<Time>,
     mut bounce_event_writer: EventWriter<BounceBoomerangEvent>,
 ) -> Result {
     for (boomerang_entity, boomerang, mut transform) in flying_boomerangs.iter_mut() {
         let target = boomerang
             .path
-            .front()
+            .get(boomerang.path_index + 1)
             .ok_or(format!("No path for boomerang {boomerang:?}"))?;
 
         let target_position = match target {
@@ -179,7 +189,7 @@ fn move_flying_boomerangs(
             continue;
         };
 
-        let distance_travelled_this_frame = boomerang.speed * time.delta_secs();
+        let distance_travelled_this_frame = boomerang_settings.movement_speed * time.delta_secs();
         if remaining_distance <= distance_travelled_this_frame {
             send_boomerang_bounce_event(
                 &mut bounce_event_writer,
@@ -256,9 +266,9 @@ fn on_boomerang_bounce_advance_to_next_pathing_step_or_fall_down(
     for event in bounce_events.read() {
         let mut boomerang = boomerangs.get_mut(event.boomerang_entity)?;
 
-        boomerang.path.pop_front();
+        boomerang.path_index += 1;
 
-        if boomerang.path.is_empty() {
+        if boomerang.path_index >= boomerang.path.len() - 1 {
             commands
                 .entity(event.boomerang_entity)
                 .remove::<Flying>()
@@ -375,9 +385,10 @@ fn on_throw_boomerang_spawn_boomerang(
 ) -> Result {
     for event in event_reader.read() {
         // add player as the last node on the path
-        let mut path = event.target.clone();
-        path.push(BoomerangTargetKind::Entity(event.thrower_entity));
-        let path = VecDeque::from(path);
+        let thrower = BoomerangTargetKind::Entity(event.thrower_entity);
+        let mut path = vec![thrower];
+        path.append(&mut event.target.clone());
+        path.push(thrower);
 
         // spawn the 'rang
         commands.spawn((
@@ -388,10 +399,7 @@ fn on_throw_boomerang_spawn_boomerang(
                     .translation
                     .with_y(BOOMERANG_FLYING_HEIGHT),
             ),
-            Boomerang {
-                path,
-                speed: boomerang_stats.movement_speed,
-            },
+            Boomerang::new(path),
             Flying,
             Mesh3d(boomerang_assets.mesh.clone()),
             MeshMaterial3d(boomerang_assets.material.clone()),

--- a/src/demo/boomerang/mod.rs
+++ b/src/demo/boomerang/mod.rs
@@ -12,6 +12,9 @@ use bevy::time::Time;
 use bevy_enhanced_input::events::Fired;
 use log::error;
 use std::collections::VecDeque;
+use boomerang_settings::BoomerangSettings;
+
+pub mod boomerang_settings;
 
 pub const BOOMERANG_FLYING_HEIGHT: f32 = 0.5;
 
@@ -86,31 +89,14 @@ struct BoomerangPathPreview {
     target_entity: Option<Entity>,
 }
 
-/// Current set of stats of our boomerang
-#[derive(Resource)]
-struct BoomerangSettings {
-    movement_speed: f32,
-    rotations_per_second: f32,
-    falling_speed: f32,
-}
-
-impl Default for BoomerangSettings {
-    fn default() -> Self {
-        Self {
-            movement_speed: 30.0,
-            rotations_per_second: 12.0,
-            falling_speed: 5.0,
-        }
-    }
-}
-
 pub fn plugin(app: &mut App) {
+    app.add_plugins(boomerang_settings::plugin);
+    
     app.init_gizmo_group::<BoomerangPreviewGizmos>();
     app.add_event::<ThrowBoomerangEvent>();
     app.add_event::<BounceBoomerangEvent>();
     app.add_event::<BoomerangHasFallenOnGroundEvent>();
     app.init_resource::<BoomerangAssets>();
-    app.init_resource::<BoomerangSettings>();
 
     app.add_systems(
         Update,

--- a/src/demo/boomerang/mod.rs
+++ b/src/demo/boomerang/mod.rs
@@ -10,8 +10,8 @@ use bevy::math::Dir3;
 use bevy::prelude::*;
 use bevy::time::Time;
 use bevy_enhanced_input::events::Fired;
-use log::error;
 use boomerang_settings::BoomerangSettings;
+use log::error;
 
 pub mod boomerang_settings;
 
@@ -27,7 +27,7 @@ struct Boomerang {
     progress_on_current_segment: f32, // value from 0.0 to 1.0
 }
 impl Boomerang {
-    pub fn new (path: Vec<BoomerangTargetKind>) -> Self {
+    pub fn new(path: Vec<BoomerangTargetKind>) -> Self {
         Self {
             path,
             path_index: 0,
@@ -167,7 +167,8 @@ fn move_flying_boomerangs(
         let target = &boomerang
             .path
             .get(boomerang.path_index + 1)
-            .ok_or(format!("No path for boomerang {boomerang:?}"))?.clone();
+            .ok_or(format!("No path for boomerang {boomerang:?}"))?
+            .clone();
 
         let target_position = match target {
             BoomerangTargetKind::Entity(entity) => all_other_transforms
@@ -191,7 +192,11 @@ fn move_flying_boomerangs(
         };
 
         // todo make this a util fn
-        let origin_position = match boomerang.path.get(boomerang.path_index).ok_or(format!("No Origin for boomerang: {:?}", boomerang))? {
+        let origin_position = match boomerang
+            .path
+            .get(boomerang.path_index)
+            .ok_or(format!("No Origin for boomerang: {:?}", boomerang))?
+        {
             BoomerangTargetKind::Entity(entity) => all_other_transforms
                 .get(*entity)?
                 .translation

--- a/src/demo/mod.rs
+++ b/src/demo/mod.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 
 mod aim_mode;
 mod animation;
-mod boomerang;
+pub mod boomerang;
 mod camera;
 mod enemy;
 mod input;

--- a/src/dev_tools/mod.rs
+++ b/src/dev_tools/mod.rs
@@ -1,5 +1,6 @@
 //! Development tools for the game. This plugin is only enabled in dev builds.
 
+use crate::demo::boomerang::boomerang_settings::boomerang_dev_tools_plugin;
 use crate::screens::Screen;
 use bevy::dev_tools::states::log_transitions;
 use bevy::prelude::*;
@@ -8,7 +9,6 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use iyes_perf_ui::PerfUiPlugin;
 use iyes_perf_ui::entries::{PerfUiFramerateEntries, PerfUiWindowEntries};
 use iyes_perf_ui::prelude::{PerfUiPosition, PerfUiRoot};
-use crate::demo::boomerang::boomerang_settings::boomerang_dev_tools_plugin;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_plugins((

--- a/src/dev_tools/mod.rs
+++ b/src/dev_tools/mod.rs
@@ -8,6 +8,7 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use iyes_perf_ui::PerfUiPlugin;
 use iyes_perf_ui::entries::{PerfUiFramerateEntries, PerfUiWindowEntries};
 use iyes_perf_ui::prelude::{PerfUiPosition, PerfUiRoot};
+use crate::demo::boomerang::boomerang_settings::boomerang_dev_tools_plugin;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_plugins((
@@ -22,6 +23,7 @@ pub(super) fn plugin(app: &mut App) {
             enable_multipass_for_primary_context: true,
         },
         WorldInspectorPlugin::new(),
+        boomerang_dev_tools_plugin,
     ));
 
     // Log `Screen` state transitions.


### PR DESCRIPTION
Now boomerangs tween between a min and max velocity and rotation speed based on where they are in their current flight segment. A segment is the line between two waypoints in the boomerang's path. When there's a single target, it's easy. When there's a whole list of targets, we treat each segment as independent of the others for tweening purposes.

To help tune this, there's a dedicated egui tool:

![image](https://github.com/user-attachments/assets/42844400-7ead-462b-874a-2c6301461bb2)

Bevy examples include a nice visual of the different functions https://bevyengine.org/examples/animation/easing-functions/
![image](https://github.com/user-attachments/assets/005e9431-34b6-4ee9-8618-16e95d5f2e2c)

