### PR TITLE
Quick crash fix

### DIFF
--- a/src/demo/boomerang/mod.rs
+++ b/src/demo/boomerang/mod.rs
@@ -454,7 +454,7 @@ fn on_boomerang_collision(
         let BoomerangTargetKind::Entity(target) = event._bounce_on else {
             continue;
         };
-        println!("Boomerang Collision on target {:?}", target);
+        println!("Boomerang Collision on target {target:?}");
         if healths.contains(target) {
             commands.entity(target).trigger(HealthEvent::Damage(1));
             println!("Fired Health Damage Event");

--- a/src/demo/health.rs
+++ b/src/demo/health.rs
@@ -93,9 +93,9 @@ fn on_damage_event(
     for CollisionStarted(entity1, entity2) in collision_event.read() {
         println!("Collision Event Read");
         for health_entity in health_query.iter() {
-            println!("Heath Found for entity {:?}", health_entity);
+            println!("Heath Found for entity {health_entity:?}");
             for (damager_entity, damager) in damager_query.iter() {
-                println!("Damager Found for entity {:?}", damager_entity);
+                println!("Damager Found for entity {damager_entity:?}");
                 if (*entity1 == health_entity || *entity2 == health_entity)
                     && (*entity1 == damager_entity || *entity2 == damager_entity)
                 {


### PR DESCRIPTION
Boomerangs on the floor were targetable. We're planning to add catching anyway (which means we won't have floor 'rangs) so a quick fix to the crash (and clutter) is to despawn them once they're finished falling.