### PR TITLE
Time improvements

### DIFF
--- a/src/gameplay/camera.rs
+++ b/src/gameplay/camera.rs
@@ -3,8 +3,8 @@ use bevy::app::{App, Startup, Update};
 use bevy::color::Color;
 use bevy::core_pipeline::bloom::Bloom;
 use bevy::core_pipeline::tonemapping::Tonemapping;
-use bevy::math::{Vec2, Vec3};
-use bevy::prelude::ReflectComponent;
+use bevy::math::{EulerRot, Vec2, Vec3};
+use bevy::prelude::{Changed, Quat, ReflectComponent};
 use bevy::prelude::{
     Camera, Camera3d, Commands, Component, Entity, EventReader, IsDefaultUiCamera, Msaa, Name,
     OnEnter, OnExit, PerspectiveProjection, Projection, Query, Real, Reflect, Res, Single, Time,
@@ -104,6 +104,36 @@ fn camera_follow(
     );
 
     Ok(())
+}
+
+// ================
+// CAMERA FORWARD TRACKING
+// ================
+
+#[derive(Component, Debug, Reflect, Default)]
+#[reflect(Component)]
+pub struct CameraForward {
+    yaw_rotation: Quat,
+}
+impl CameraForward {
+    pub fn rotate_to_forward(self: &mut Self, transform: Transform) {
+        let camera_right = transform
+            .right()
+            .as_vec3()
+            .with_y(0.)
+            .normalize_or_zero();
+        let camera_forward = transform.forward()
+            .as_vec3()
+            .with_y(0.)
+            .normalize_or_zero();
+    }
+}
+
+fn update_camera_forward_when_camera_moves(mut cameras: Query<(&Transform, &mut CameraForward), With<Camera3d>>) {
+    for (transform, mut camera_forward) in cameras.iter_mut() {
+        let (yaw, _, _) = transform.rotation.to_euler(EulerRot::XYZ);
+        let yaw_rotation = Quat::from_rotation_y(yaw);
+    }
 }
 
 // ================

--- a/src/gameplay/enemy.rs
+++ b/src/gameplay/enemy.rs
@@ -12,7 +12,7 @@ use bevy::color;
 use bevy::ecs::entity::EntityHashSet;
 use bevy::prelude::*;
 use rand::{Rng, thread_rng};
-use crate::gameplay::time_dilation::{RotationDilated, VelocityDilated};
+use crate::gameplay::time_dilation::{DilatedTime, RotationDilated, VelocityDilated};
 
 pub fn plugin(app: &mut App) {
     app.register_type::<EnemySpawnPoint>();
@@ -162,7 +162,7 @@ fn attack_target_after_delay(
         ),
         With<Enemy>,
     >,
-    time: Res<Time<Real>>,
+    time: Res<DilatedTime>,
     player_query: Single<&Transform, With<Player>>,
     boomerang_assets: Res<BoomerangAssets>,
 ) {

--- a/src/gameplay/enemy.rs
+++ b/src/gameplay/enemy.rs
@@ -12,6 +12,7 @@ use bevy::color;
 use bevy::ecs::entity::EntityHashSet;
 use bevy::prelude::*;
 use rand::{Rng, thread_rng};
+use crate::gameplay::time_dilation::{RotationDilated, VelocityDilated};
 
 pub fn plugin(app: &mut App) {
     app.register_type::<EnemySpawnPoint>();
@@ -171,6 +172,11 @@ fn attack_target_after_delay(
     {
         can_delay.timer.tick(time.delta());
         if can_delay.timer.just_finished() && attacker_target.target_entity.is_some() {
+
+            let bullet_velocity = (player_transform.translation - origin_transform.translation)
+                .normalize_or_zero()
+                * ranged_attack.speed;
+
             commands.spawn((
                 Name::new("Bullet"),
                 Transform::from_translation(origin_transform.translation),
@@ -180,11 +186,8 @@ fn attack_target_after_delay(
                 Collider::sphere(0.2),
                 CollisionLayers::new(GameLayer::Bullet, [GameLayer::Player, GameLayer::Terrain]),
                 RigidBody::Kinematic,
-                LinearVelocity(
-                    (player_transform.translation - origin_transform.translation)
-                        .normalize_or_zero()
-                        * ranged_attack.speed,
-                ),
+                VelocityDilated(bullet_velocity),
+                RotationDilated(10.),
                 CanDamage(1),
                 CollisionEventsEnabled,
             ));

--- a/src/gameplay/level.rs
+++ b/src/gameplay/level.rs
@@ -30,7 +30,7 @@ impl FromWorld for LevelAssets {
 /// A system that spawns the main level.
 pub fn spawn_level(
     mut commands: Commands,
-    // level_assets: Res<LevelAssets>, // TODO: uncomment to add music back in
+    _level_assets: Res<LevelAssets>,
     asset_server: Res<AssetServer>,
 ) {
     commands.spawn((
@@ -41,7 +41,7 @@ pub fn spawn_level(
         children![
             (
                 Name::new("Gameplay Music"),
-                // music(level_assets.music.clone()), // TODO: uncomment to add music back in
+                // music(_level_assets.music.clone()), // TODO: uncomment to add music back in
             ),
             (
                 Name::new("Environment"),

--- a/src/gameplay/mod.rs
+++ b/src/gameplay/mod.rs
@@ -13,6 +13,7 @@ mod input;
 pub mod level;
 mod mouse_position;
 mod player;
+mod time_dilation;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_plugins((
@@ -24,5 +25,6 @@ pub(super) fn plugin(app: &mut App) {
         boomerang::plugin,
         enemy::plugin,
         health_and_damage::plugin,
+        time_dilation::plugin,
     ));
 }

--- a/src/gameplay/mod.rs
+++ b/src/gameplay/mod.rs
@@ -14,6 +14,7 @@ pub mod level;
 mod mouse_position;
 mod player;
 mod time_dilation;
+mod velocity;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_plugins((
@@ -26,5 +27,6 @@ pub(super) fn plugin(app: &mut App) {
         enemy::plugin,
         health_and_damage::plugin,
         time_dilation::plugin,
+        velocity::plugin,
     ));
 }

--- a/src/gameplay/time_dilation.rs
+++ b/src/gameplay/time_dilation.rs
@@ -35,6 +35,11 @@ impl DilatedTime {
     /// The "minimum possible" speed time can go. We never fully pause the game during slo-mo.
     const SLOW_MO_SCALING_FACTOR: f32 = 0.1;
 
+    /// Intended to be drop-in replacement for Res<Time>
+    pub fn delta(&self) -> Duration {
+        self.delta
+    }
+    /// Intended to be drop-in replacement for Res<Time>
     pub fn delta_secs(&self) -> f32 {
         self.delta.as_secs_f32()
     }
@@ -96,4 +101,3 @@ fn rotate_anything_with_a_rotation(
         transform.rotate_local_y(rotation_speed * time.delta_secs());
     }
 }
-

--- a/src/gameplay/time_dilation.rs
+++ b/src/gameplay/time_dilation.rs
@@ -1,0 +1,44 @@
+use crate::AppSystems::PreTickTimers;
+use bevy::prelude::*;
+use std::time::Duration;
+
+pub fn plugin(app: &mut App) {
+    app.init_resource::<DilatedTime>();
+    app.add_systems(Update, scale_time.in_set(PreTickTimers));
+}
+
+/// Used by anything that needs to move in slow motion. We update this once per
+/// frame, then everything with a velocity simply uses the delta from this
+/// resource, rather that Res<Time>::delta
+#[derive(Resource, Debug, Reflect)]
+#[reflect(Resource)]
+pub struct DilatedTime {
+    /// How much to scale the default timer by.
+    /// E.g., at 0.5, our 60 Hz / ~16 ms/frame delta becomes ~8 ms
+    pub scaling_factor: f32,
+
+    /// Always use this to tick timers, etc. if something needs to be affected
+    /// by slow motion. If not (like screen shake) use the regular game Res<Time>
+    pub delta: Duration,
+}
+
+impl DilatedTime {
+    /// The "minimum possible" speed time can go. We never fully pause the game during slo-mo.
+    const SLOW_MO_SCALING_FACTOR: f32 = 0.1;
+}
+
+impl Default for DilatedTime {
+    fn default() -> Self {
+        Self {
+            scaling_factor: 1.0,
+            delta: Duration::from_secs(0),
+        }
+    }
+}
+
+fn scale_time(mut dilated_time_res: ResMut<DilatedTime>, actual_time: Res<Time>) -> Result {
+    let scale = dilated_time_res.scaling_factor;
+    let actual_delta = actual_time.delta();
+    dilated_time_res.delta = actual_delta.mul_f32(scale);
+    Ok(())
+}

--- a/src/gameplay/velocity.rs
+++ b/src/gameplay/velocity.rs
@@ -1,0 +1,7 @@
+use bevy::ecs::error::info;
+use crate::gameplay::time_dilation::DilatedTime;
+use bevy::prelude::*;
+
+pub fn plugin(app: &mut App) {
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ impl Plugin for AppPlugin {
         app.configure_sets(
             Update,
             (
+                AppSystems::PreTickTimers,
                 AppSystems::TickTimers,
                 AppSystems::RecordInput,
                 AppSystems::Update,
@@ -82,6 +83,8 @@ impl Plugin for AppPlugin {
 /// call above.
 #[derive(SystemSet, Debug, Clone, Copy, Eq, PartialEq, Hash, PartialOrd, Ord)]
 enum AppSystems {
+    /// Happens before timers tick, for time-manipulation stuff that subsequent timers need
+    PreTickTimers,
     /// Tick timers.
     TickTimers,
     /// Record player input.


### PR DESCRIPTION
Introduces a "DilatedTime" resource which we can set/reset/tween however we want. Switched all virtual clock-based updates to use this instead. This gets us a few things:

- fine-grained controllable time using a scaling factor on a single resource 1.0 is real time. 0.1 is 10% speed. 2.0 is 2x. etc.
- SMOOTH animation during slow mo. I'm pretty sure using a clock for this meant updates were only happening every 160ms, so that's why the boomerangs looked choppy. Now, we're still updating at 60fps, we're just moving things 1/10th the distance they normally would during each frame during slow mo

a couple of bug fixes
- the player launching into space when hit seems to be gone. I wonder if it had to do with clock speed being tied to player velocity, leading to a feedback loop? Not sure about this one
- choppy boomerangs are smooth now in slo mo
- the prior version had a bug where enemies' attack timers progressed in real time, so they effectively shot 10x as fast during slow mo. This version ticks their timers using the same DilatedTime resource that everything else is using, which means they'll take 3 game-seconds to attack, independent of how fast the game is running


