### PR TITLE
Streamlined attacking to focus on chain attacks

### DIFF
--- a/src/gameplay/aim_mode.rs
+++ b/src/gameplay/aim_mode.rs
@@ -20,7 +20,6 @@ use tracing::{debug, info, warn};
 // ===================
 // AIM MODE
 // ==================
-use crate::asset_tracking::LoadResource;
 use crate::gameplay::time_dilation::DilatedTime;
 use bevy::prelude::*;
 
@@ -46,9 +45,6 @@ pub fn plugin(app: &mut App) {
         |mut t: ResMut<DilatedTime>| t.scaling_factor = 1.0,
     );
 
-    // sound effect!
-    // app.load_resource::<AimModeAssets>()
-    //     .add_systems(OnEnter(AimModeState::Aiming), play_aim_mode_sound_effect);
     app.add_observer(play_enemy_targeted_sound_effect);
 }
 
@@ -91,12 +87,6 @@ pub fn exit_aim_mode(
     next_state.set(AimModeState::Normal);
 }
 
-pub fn play_aim_mode_sound_effect(mut commands: Commands, assets: Option<Res<AimModeAssets>>) {
-    let Some(assets) = assets else {
-        return;
-    };
-    commands.spawn(sound_effect(assets.entering_aim_mode.clone()));
-}
 // =====================
 // AUDIO
 // =====================

--- a/src/gameplay/aim_mode.rs
+++ b/src/gameplay/aim_mode.rs
@@ -47,8 +47,8 @@ pub fn plugin(app: &mut App) {
     );
 
     // sound effect!
-    app.load_resource::<AimModeAssets>()
-        .add_systems(OnEnter(AimModeState::Aiming), play_aim_mode_sound_effect);
+    // app.load_resource::<AimModeAssets>()
+    //     .add_systems(OnEnter(AimModeState::Aiming), play_aim_mode_sound_effect);
     app.add_observer(play_enemy_targeted_sound_effect);
 }
 

--- a/src/gameplay/camera.rs
+++ b/src/gameplay/camera.rs
@@ -7,9 +7,9 @@ use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::math::{Vec2, Vec3};
 use bevy::prelude::ReflectComponent;
 use bevy::prelude::{
-    default, Camera, Camera3d, Commands, Component, Entity, EventReader, IsDefaultUiCamera, Msaa,
-    Name, OnEnter, OnExit, PerspectiveProjection, Projection, Query, Real, Reflect, Res, Single,
-    Time, Timer, TimerMode, Transform, Window, With, Without,
+    Camera, Camera3d, Commands, Component, Entity, EventReader, IsDefaultUiCamera, Msaa, Name,
+    OnEnter, OnExit, PerspectiveProjection, Projection, Query, Real, Reflect, Res, Single, Time,
+    Timer, TimerMode, Transform, Window, With, Without, default,
 };
 use bevy::render::camera::Exposure;
 use rand::Rng;

--- a/src/gameplay/camera.rs
+++ b/src/gameplay/camera.rs
@@ -1,4 +1,3 @@
-use crate::gameplay::aim_mode::AimModeState;
 use crate::gameplay::boomerang::BounceBoomerangEvent;
 use bevy::app::{App, Startup, Update};
 use bevy::color::Color;
@@ -8,8 +7,8 @@ use bevy::math::{Vec2, Vec3};
 use bevy::prelude::ReflectComponent;
 use bevy::prelude::{
     Camera, Camera3d, Commands, Component, Entity, EventReader, IsDefaultUiCamera, Msaa, Name,
-    OnEnter, OnExit, PerspectiveProjection, Projection, Query, Real, Reflect, Res, Single, Time,
-    Timer, TimerMode, Transform, Window, With, Without, default,
+    PerspectiveProjection, Projection, Query, Real, Reflect, Res, Single, Time, Timer, TimerMode,
+    Transform, Window, With, Without, default,
 };
 use bevy::render::camera::Exposure;
 use rand::Rng;
@@ -18,8 +17,6 @@ pub fn plugin(app: &mut App) {
     // systems
     app.add_systems(Startup, spawn_camera);
     app.add_systems(Update, camera_follow);
-    // app.add_systems(OnEnter(AimModeState::Aiming), camera_enter_aim_mode);
-    // app.add_systems(OnExit(AimModeState::Aiming), camera_exit_aim_mode);
     app.add_systems(Update, start_shake_on_boomerang_bounce);
     app.add_systems(Update, (update_screen_shake, tick_shake_timers));
 
@@ -105,17 +102,6 @@ fn camera_follow(
     );
 
     Ok(())
-}
-
-// ================
-// AIM MODE
-// ================
-fn camera_enter_aim_mode(camera: Single<&mut Transform, With<Camera>>) {
-    // just a really subtle zoom out when aiming
-    camera.into_inner().scale.z = 0.9;
-}
-fn camera_exit_aim_mode(camera: Single<&mut Transform, With<Camera>>) {
-    camera.into_inner().scale.z = 1.0;
 }
 
 // ===============

--- a/src/gameplay/camera.rs
+++ b/src/gameplay/camera.rs
@@ -7,9 +7,9 @@ use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::math::{Vec2, Vec3};
 use bevy::prelude::ReflectComponent;
 use bevy::prelude::{
-    Camera, Camera3d, Commands, Component, Entity, EventReader, IsDefaultUiCamera, Msaa, Name,
-    OnEnter, OnExit, PerspectiveProjection, Projection, Query, Real, Reflect, Res, Single, Time,
-    Timer, TimerMode, Transform, Window, With, Without, default,
+    default, Camera, Camera3d, Commands, Component, Entity, EventReader, IsDefaultUiCamera, Msaa,
+    Name, OnEnter, OnExit, PerspectiveProjection, Projection, Query, Real, Reflect, Res, Single,
+    Time, Timer, TimerMode, Transform, Window, With, Without,
 };
 use bevy::render::camera::Exposure;
 use rand::Rng;
@@ -18,8 +18,8 @@ pub fn plugin(app: &mut App) {
     // systems
     app.add_systems(Startup, spawn_camera);
     app.add_systems(Update, camera_follow);
-    app.add_systems(OnEnter(AimModeState::Aiming), camera_enter_aim_mode);
-    app.add_systems(OnExit(AimModeState::Aiming), camera_exit_aim_mode);
+    // app.add_systems(OnEnter(AimModeState::Aiming), camera_enter_aim_mode);
+    // app.add_systems(OnExit(AimModeState::Aiming), camera_exit_aim_mode);
     app.add_systems(Update, start_shake_on_boomerang_bounce);
     app.add_systems(Update, (update_screen_shake, tick_shake_timers));
 
@@ -112,7 +112,7 @@ fn camera_follow(
 // ================
 fn camera_enter_aim_mode(camera: Single<&mut Transform, With<Camera>>) {
     // just a really subtle zoom out when aiming
-    camera.into_inner().scale.z = 0.97;
+    camera.into_inner().scale.z = 0.9;
 }
 fn camera_exit_aim_mode(camera: Single<&mut Transform, With<Camera>>) {
     camera.into_inner().scale.z = 1.0;

--- a/src/gameplay/input.rs
+++ b/src/gameplay/input.rs
@@ -25,7 +25,7 @@ pub struct AimModeAction;
 struct ControlSettings;
 
 impl ControlSettings {
-    const AIM_MODE_DELAY: f32 = 0.3;
+    const AIM_MODE_DELAY: f32 = 0.001;
 }
 
 fn regular_binding(
@@ -45,10 +45,10 @@ fn regular_binding(
         .with_modifiers(DeadZone::default());
 
     // 'Tap' means you need to release within the specified time for it to fire
-    actions
-        .bind::<FireBoomerangAction>()
-        .to(MouseButton::Left)
-        .with_conditions(Tap::new(ControlSettings::AIM_MODE_DELAY));
+    // actions
+    //     .bind::<FireBoomerangAction>()
+    //     .to(MouseButton::Left)
+    //     .with_conditions(Tap::new(ControlSettings::AIM_MODE_DELAY));
 
     // 'Hold' fires only after the specified time has passed while the input remains pressed
     actions

--- a/src/gameplay/time_dilation.rs
+++ b/src/gameplay/time_dilation.rs
@@ -33,7 +33,7 @@ pub struct DilatedTime {
 
 impl DilatedTime {
     /// The "minimum possible" speed time can go. We never fully pause the game during slo-mo.
-    pub const SLOW_MO_SCALING_FACTOR: f32 = 0.05;
+    pub const SLOW_MO_SCALING_FACTOR: f32 = 0.1;
 
     /// Intended to be drop-in replacement for `Res<Time>`
     pub fn delta(&self) -> Duration {


### PR DESCRIPTION
![demo](https://github.com/user-attachments/assets/99d1143e-1e09-42aa-ba86-9a09753161bf)

Removed distinction between short ranged tap-to-attack and chain attack.

Now all attacks are initiated by painting your cursor over the enemy. This can either be done as a quick tap over one enemy or as a long drag over multiple enemies.

While in painting mode, slow-mo is active. I have removed the eagle call SFX and the camera zoom effect from the chain attack since the player is now using it all of the time.

Slightly reduced slow mo effect