### PR TITLE
Fix enemy getting stuck on walls

### DIFF
--- a/src/gameplay/enemy.rs
+++ b/src/gameplay/enemy.rs
@@ -94,8 +94,8 @@ fn spawn_enemies_on_enemy_spawn_points(
                 [
                     GameLayer::Player,
                     GameLayer::Boomerang,
-                    GameLayer::Terrain,
-                    GameLayer::Default,
+                    // GameLayer::Terrain,
+                    // GameLayer::Default,
                 ],
             ),
             LinearVelocity::ZERO,


### PR DESCRIPTION
Simply don't make them interact with walls :P They'll "play fair" because they still follow navmesh nodes which generally respect walls, they just won't get stuck on corners and look silly